### PR TITLE
Fixed panic error when `token.Method != ja.signer`

### DIFF
--- a/jwtauth.go
+++ b/jwtauth.go
@@ -117,7 +117,7 @@ func (ja *JwtAuth) Verify(paramAliases ...string) func(chi.Handler) chi.Handler 
 				return
 			}
 
-			if !token.Valid || token.Method != ja.signer {
+			if token == nil || !token.Valid || token.Method != ja.signer {
 				err = ErrUnauthorized
 				ctx = ja.SetContext(ctx, token, err)
 				next.ServeHTTPC(ctx, w, r)


### PR DESCRIPTION
Fixed an issue with panic error when token supplied was signed with a different `alg` method than expected.
```go
	...
	token, err := ja.Decode(tokenStr)
	if err != nil || !token.Valid || token.Method != ja.signer {
		switch err.Error() { ... } // panic when `err == nil` but `token.Method != ja.signer`
		...
	}

```

Added test to cover this case.